### PR TITLE
Italicize 'm/z' in plot label

### DIFF
--- a/spectrum_utils/plot.py
+++ b/spectrum_utils/plot.py
@@ -83,7 +83,7 @@ def spectrum(spec: MsmsSpectrum, color_ions: bool = True,
 
     ax.tick_params(axis='both', which='both', labelsize='small')
 
-    ax.set_xlabel('m/z', style="italic")
+    ax.set_xlabel('m/z', style='italic')
     ax.set_ylabel('Intensity')
 
     return ax

--- a/spectrum_utils/plot.py
+++ b/spectrum_utils/plot.py
@@ -83,7 +83,7 @@ def spectrum(spec: MsmsSpectrum, color_ions: bool = True,
 
     ax.tick_params(axis='both', which='both', labelsize='small')
 
-    ax.set_xlabel('m/z')
+    ax.set_xlabel('m/z', style="italic")
     ax.set_ylabel('Intensity')
 
     return ax


### PR DESCRIPTION
Minor change to italicize "m/z" per IUPAC standards. 