### PR TITLE
Bugfix/multiple static mod set

### DIFF
--- a/spectrum_utils/proforma.ebnf
+++ b/spectrum_utils/proforma.ebnf
@@ -57,7 +57,7 @@ monosaccharide: MONOSACCHARIDE MONOSACCHARIDE_COUNT?
 MONOSACCHARIDE: "sulfate"i | "phosphate"i | "en,a-Hex"i | "d-Hex"i | "a-Hex"i
     | "Tri"i | "Tet"i | "Sug"i | "Pen"i | "Oct"i | "Non"i | "Neu5Gc"i
     | "Neu5Ac"i | "Neu"i | "HexS"i | "HexP"i | "HexNS"i | "HexNAc(S)"i
-    | "HexNAc"i | "HexN"i | "Hex"i | "Hep"i | "Fuc"i | "Dec"i
+    | "HexNAc"i | "HexN"i | "Hex"i | "Hep"i | "Fuc"i | "Dec"i | " "
 MONOSACCHARIDE_COUNT: INT
 
 info.5: "Info:"i TEXT

--- a/spectrum_utils/spectrum.py
+++ b/spectrum_utils/spectrum.py
@@ -9,6 +9,7 @@ except ImportError:
     import pyteomics.mass as pmass
 
 from spectrum_utils import utils
+from spectrum_utils.proforma import parse as parse_proforma
 
 
 _aa_mass = {
@@ -684,7 +685,7 @@ class MsmsSpectrum:
         self.retention_time = retention_time
         if peptide is not None:
             # Parse ProForma peptide.
-            self.peptide, self.modifications = _parse_proforma(peptide)
+            self.peptide, self.modifications = parse_proforma(peptide)
 
             self.peptide = peptide.upper()
             for aa in self.peptide:

--- a/spectrum_utils/spectrum.py
+++ b/spectrum_utils/spectrum.py
@@ -1,5 +1,6 @@
 import operator
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+import warnings
 
 import numba as nb
 import numpy as np
@@ -38,6 +39,11 @@ def static_modification(amino_acid: str, mass_diff: float) -> None:
         monoisotopic mass.
     """
     global aa_mass
+    if _aa_mass[amino_acid] != aa_mass[amino_acid]:
+        curr_mass_diff = aa_mass[amino_acid] - _aa_mass[amino_acid]
+        warnings.warn((
+            f"Amino acid {amino_acid} already has a mass offset of {curr_mass_diff},"
+            f" the provided mass of {mass_diff} will be added to that"))
     aa_mass[amino_acid] += mass_diff
 
 

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -75,6 +75,9 @@ def test_get_theoretical_fragments_static_mod():
         fragment_mz = fragments[f'{fragment.ion_type}_{fragment.charge}']
         assert fragment.calc_mz == pytest.approx(fragment_mz)
     assert spectrum.aa_mass['Y'] == pytest.approx(163.06333 + 79.96633)
+    with pytest.warns(UserWarning):
+        spectrum.static_modification('Y', 79.96633)
+        assert spectrum.aa_mass['Y'] != pytest.approx(163.06333)
     spectrum.reset_modifications()
     assert spectrum.aa_mass['Y'] == pytest.approx(163.06333)
 


### PR DESCRIPTION

This PR Addresses issues:
- https://github.com/bittremieux/spectrum_utils/issues/25 - Adds a warning when setting static modifications twice
- https://github.com/bittremieux/spectrum_utils/issues/18 - Completes the implementation of proforma annotations in the package, as defined by passing all tests for compliance with the 2.0 standard (except for one mentioned later)

Currently unsolved:
- How should synonyms be handled for glycans (NeuAc is not in the keys, but Neu5Ac is and they are the same....)? (I dont really work with glycans so I dont know how prevalent this issue is)

``` 
 assert (proforma.parse('{Glycan:Hex}{Glycan:NeuAc}EMEVNESPEK') ==
         ('EMEVNESPEK', {}))
```

- The parser does not return information on uncertainty, therefore its not possible to get the annotation from the parsed sequence (in some cases), and makes the calculation of precursor masses wrong for any case that has unknown position or labile modifications.
-  Should a code formatter be implemented for the future of the project (I generaly use `black` but it makes a lot of changes in this project and I don't want to screw up your "blame")

Let me know what you think.
Kindest wishes
Sebastian  
