### PR TITLE
Add functionality for plotting mass errors

### DIFF
--- a/spectrum_utils/plot.py
+++ b/spectrum_utils/plot.py
@@ -187,7 +187,7 @@ def spectrum(
 
     _format_ax(ax, grid)
     ax.yaxis.set_major_formatter(mticker.PercentFormatter(xmax=1.0))
-    ax.set_ylim(*(0, 1) if not mirror_intensity else (-1, 0))
+    ax.set_ylim(*(0, 1.1) if not mirror_intensity else (-1.1, 0))
     ax.set_ylabel("Intensity")
 
     if len(spec.mz) == 0:


### PR DESCRIPTION
This PR adds a function to `spectrum_utils.plot` to plot MS2 mass errors as a bubble plot: 

```python
import spectrum_utils.plot as sup
sup.mass_errors(observed_spec)
```

![dcf7a1be-c974-4e26-9159-3c44fbcc4840](https://github.com/bittremieux/spectrum_utils/assets/26458971/085541ca-c86b-49a0-b9a9-c85a4e3eb130)

Ultimately, my goal was to be able to generate a plot similar to the ones produced by [IPSA](http://www.interactivepeptidespectralannotator.com/PeptideAnnotator.html) / [USE](https://github.com/kusterlab/universal_spectrum_explorer), which is now possible with some additional wrapper code:

```python
import matplotlib.pyplot as plt
import spectrum_utils.plot as sup

fig, (top_ax, middle_ax, bottom_ax) = plt.subplots(
    *(3,1),
    figsize=(12, 8),
    sharex=True,
    gridspec_kw={'height_ratios': [1, 0.5,1 ]}
)

sup. Spectrum(observed_spec, ax=top_ax)
sup.mass_errors(observed_spec, ax=middle_ax)
sup. Spectrum(predicted_spec, mirror_intensity=True, ax=bottom_ax)

top_ax.set_xlabel('')
middle_ax.set_xlabel('')
```

![c9ac17a6-e334-49cf-85c8-a568ed885258](https://github.com/bittremieux/spectrum_utils/assets/26458971/90e6ed75-11d6-41d1-8f08-93f9b597f987)


However, since all `spectrum_utils.plot` functions operate at the ax-level (not figure-level), I'm not sure if you would prefer to implement such a function or not.

Of note: I also changed the `sup.spectrum` ylim to 1.1 to avoid overflow of the peak annotation labels, which I very often had. This commit can be easily reverted if you do not like it.

Let me know what you think!